### PR TITLE
Update AcerolaFX_GameplayLowest.ini

### DIFF
--- a/Presets/AcerolaFX_GameplayLowest.ini
+++ b/Presets/AcerolaFX_GameplayLowest.ini
@@ -88,12 +88,6 @@ _Offset=1.42856995e+02
 [AcerolaFX_Gamma.fx]
 _Gamma=1.100000
 
-[AcerolaFX_Sharpness.fx]
-_Filter=1
-_Offset=0.000000
-_Sharpness=1.000000
-_SharpnessFalloff=0.000000
-
 [AcerolaFX_Tonemapping.fx]
 _A=0.100000
 _B=0.500000


### PR DESCRIPTION
The Sharpness shader has a noticeable impact on framerates in many areas. This can be easily seen in player housing areas where animated foliage is more common. On Lowest, it should not be enabled.